### PR TITLE
Import Keter UI code

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 =====================
 
+Copyright (C) 2014–2016 by Keter authors
 Copyright (C) 2017 by Euclid authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Readme.md
+++ b/Readme.md
@@ -27,12 +27,21 @@ Run
 ---
 
 To run the manual test projects (just stubs for now) for JVM and Scala.js,
-execute the following commands in your terminal:
+execute the following commands in your terminal.
+
+For JVM test:
 
 ```console
 $ sbt 'project euclidJVM' run
-$ sbt 'project euclidJS' run
 ```
+
+For JS test:
+
+```console
+$ sbt 'project euclidJS' fastOptJS::webpack
+```
+
+After that open `js/target/scala-2.12/classes/index.html` in your browser.
 
 [build-appveyor]: https://ci.appveyor.com/project/ForNeVeR/euclid/branch/master
 [build-travis]: https://travis-ci.org/codingteam/euclid

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,10 @@ lazy val euclid = crossProject.in(file("."))
   )
   .jvmSettings()
   .jsSettings(
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.3",
+    npmDependencies in Compile += "rot-js" -> "0.6.2",
     scalaJSUseMainModuleInitializer := true
   )
 
 lazy val euclidJVM = euclid.jvm
-lazy val euclidJS = euclid.js
+lazy val euclidJS = euclid.js.enablePlugins(ScalaJSBundlerPlugin)

--- a/js/src/main/resources/index.html
+++ b/js/src/main/resources/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Euclid</title>
+    </head>
+    <body>
+        <script src="../scalajs-bundler/main/euclid-fastopt-bundle.js"></script>
+    </body>
+</html>

--- a/js/src/main/scala/ru/org/codingteam/euclid/EuclidJsApp.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/EuclidJsApp.scala
@@ -1,7 +1,0 @@
-package ru.org.codingteam.euclid
-
-object EuclidJsApp {
-  def main(args: Array[String]): Unit = {
-    println("Hello JS world")
-  }
-}

--- a/js/src/main/scala/ru/org/codingteam/euclid/EuclidJsApp.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/EuclidJsApp.scala
@@ -2,6 +2,6 @@ package ru.org.codingteam.euclid
 
 object EuclidJsApp {
   def main(args: Array[String]): Unit = {
-    Euclid.hello(args)
+    println("Hello JS world")
   }
 }

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/EuclidJsApp.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/EuclidJsApp.scala
@@ -1,0 +1,30 @@
+package ru.org.codingteam.euclid.js.application
+
+import org.scalajs.dom.document
+import ru.org.codingteam.euclid.js.scenes.Scene
+import ru.org.codingteam.rotjs.DisplayOptions
+import ru.org.codingteam.rotjs.ROT.Display
+
+import scala.scalajs.js
+import scala.scalajs.js.JSApp
+
+object EuclidJsApp extends JSApp {
+
+  val display: Display = new Display(js.Dynamic.literal(fontSize = 20).asInstanceOf[DisplayOptions])
+  var currentScene: Option[Scene] = None
+
+  def main(): Unit = {
+    document.body.appendChild(display.getContainer())
+    setScene(new MainMenuScene(display))
+  }
+
+  def setScene(scene: Scene): Unit = {
+    currentScene match {
+      case Some(s) => s.disable()
+      case None =>
+    }
+
+    scene.enable()
+    currentScene = Some(scene)
+  }
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuScene.scala
@@ -1,0 +1,11 @@
+package ru.org.codingteam.euclid.js.application
+
+import ru.org.codingteam.euclid.js.io.DisplayWrapper
+import ru.org.codingteam.euclid.js.scenes.ViewScene
+import ru.org.codingteam.rotjs.ROT.Display
+
+class MainMenuScene(display: Display) extends ViewScene(new DisplayWrapper(display)) {
+
+  override val components = Vector(menu(new MainMenuViewModel(this)))
+
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuScene.scala
@@ -1,10 +1,10 @@
 package ru.org.codingteam.euclid.js.application
 
-import ru.org.codingteam.euclid.js.io.DisplayWrapper
+import ru.org.codingteam.euclid.js.io.RotJsDisplay
 import ru.org.codingteam.euclid.js.scenes.ViewScene
 import ru.org.codingteam.rotjs.ROT.Display
 
-class MainMenuScene(display: Display) extends ViewScene(new DisplayWrapper(display)) {
+class MainMenuScene(display: Display) extends ViewScene(new RotJsDisplay(display)) {
 
   override val components = Vector(menu(new MainMenuViewModel(this)))
 

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuViewModel.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/MainMenuViewModel.scala
@@ -1,0 +1,15 @@
+package ru.org.codingteam.euclid.js.application
+
+import ru.org.codingteam.euclid.js.scenes.Scene
+import ru.org.codingteam.euclid.viewmodels.MenuViewModel
+
+class MainMenuViewModel(scene: Scene) extends MenuViewModel {
+  override val header = "Euclid Test Application"
+
+  override val items = Vector(
+    "New Game" -> showText(1) _,
+    "Load Game" -> showText(2) _
+  )
+
+  private def showText(x: Int)(): Unit = EuclidJsApp.setScene(new TextScene(scene.display, scene, s"Test text $x."))
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/TextScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/TextScene.scala
@@ -1,13 +1,13 @@
 package ru.org.codingteam.euclid.js.application
 
-import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.View
 import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
 import ru.org.codingteam.euclid.js.scenes.{Scene, ViewScene}
 import ru.org.codingteam.rotjs.ROT
 
 class TextScene(display: Display, parentScene: Scene, text: String) extends ViewScene(display) {
 
-  override def components: Vector[IView[Int]] =
+  override def components: Vector[View[Int]] =
     Vector(textView(text))
 
   override def onKeyDown(event: KeyboardEvent[Int]): Unit = {

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/application/TextScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/application/TextScene.scala
@@ -1,0 +1,19 @@
+package ru.org.codingteam.euclid.js.application
+
+import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
+import ru.org.codingteam.euclid.js.scenes.{Scene, ViewScene}
+import ru.org.codingteam.rotjs.ROT
+
+class TextScene(display: Display, parentScene: Scene, text: String) extends ViewScene(display) {
+
+  override def components: Vector[IView[Int]] =
+    Vector(textView(text))
+
+  override def onKeyDown(event: KeyboardEvent[Int]): Unit = {
+    event.keyCode match {
+      case c if c == ROT.VK_RETURN => EuclidJsApp.setScene(parentScene)
+      case _ =>
+    }
+  }
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/io/DisplayWrapper.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/io/DisplayWrapper.scala
@@ -1,0 +1,24 @@
+package ru.org.codingteam.euclid.js.io
+
+import ru.org.codingteam.euclid.io.{Display, TextBlockSize, TextMeasurementService}
+import ru.org.codingteam.rotjs.ROT
+
+class DisplayWrapper(display: ROT.Display) extends Display {
+  override val textMeasurement: TextMeasurementService =
+    (text: String, width: Int) => {
+      val block = ROT.Text.measure(text, width)
+      new TextBlockSize(block.width, block.height)
+    }
+
+  override def draw(x: Int, y: Int, ch: String, fg: String, bg: String): Unit = display.draw(x, y, ch, fg, bg)
+  override def draw(x: Int, y: Int, ch: Array[String], fg: String, bg: String): Unit = display.draw(x, y, ch, fg, bg)
+  override def drawText(x: Int, y: Int, text: String, maxWidth: Int): Int = display.drawText(x, y, text, maxWidth)
+
+  override def width: Int = display.getOptions().width
+  override def height: Int = display.getOptions().height
+
+  /**
+    * Clears the display.
+    */
+  override def clear(): Unit = display.clear()
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/io/RotJsDisplay.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/io/RotJsDisplay.scala
@@ -3,7 +3,7 @@ package ru.org.codingteam.euclid.js.io
 import ru.org.codingteam.euclid.io.{Display, TextBlockSize, TextMeasurementService}
 import ru.org.codingteam.rotjs.ROT
 
-class DisplayWrapper(display: ROT.Display) extends Display {
+class RotJsDisplay(display: ROT.Display) extends Display {
   override val textMeasurement: TextMeasurementService =
     (text: String, width: Int) => {
       val block = ROT.Text.measure(text, width)

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/Scene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/Scene.scala
@@ -1,0 +1,24 @@
+package ru.org.codingteam.euclid.js.scenes
+
+import org.scalajs.dom
+import org.scalajs.dom.document
+import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
+
+abstract class Scene(val display: Display) {
+
+  def keyDownListener(event: dom.KeyboardEvent): Unit = {
+    onKeyDown(new KeyboardEvent[Int](event.keyCode))
+  }
+  
+  def enable(): Unit = {
+    document.onkeydown = keyDownListener
+    render()
+  }
+
+  def disable(): Unit = {
+    document.onkeydown = null
+  }
+  
+  protected def onKeyDown(event: KeyboardEvent[Int]): Unit
+  protected def render(): Unit
+}

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/ViewScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/ViewScene.scala
@@ -1,6 +1,6 @@
 package ru.org.codingteam.euclid.js.scenes
 
-import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.View
 import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
 import ru.org.codingteam.euclid.js.application.EuclidJsApp
 import ru.org.codingteam.euclid.shape.Rectangle
@@ -11,7 +11,7 @@ import ru.org.codingteam.rotjs.ROT
 
 abstract class ViewScene(display: Display) extends Scene(display) with Logging {
 
-  def components: Vector[IView[Int]]
+  def components: Vector[View[Int]]
 
   protected def renderOnKeyDown: Boolean = EuclidJsApp.currentScene.contains(this)
 

--- a/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/ViewScene.scala
+++ b/js/src/main/scala/ru/org/codingteam/euclid/js/scenes/ViewScene.scala
@@ -1,0 +1,42 @@
+package ru.org.codingteam.euclid.js.scenes
+
+import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
+import ru.org.codingteam.euclid.js.application.EuclidJsApp
+import ru.org.codingteam.euclid.shape.Rectangle
+import ru.org.codingteam.euclid.util.Logging
+import ru.org.codingteam.euclid.viewmodels.{MenuViewModel, StaticTextViewModel, TextViewModel}
+import ru.org.codingteam.euclid.views.{MenuView, TextView}
+import ru.org.codingteam.rotjs.ROT
+
+abstract class ViewScene(display: Display) extends Scene(display) with Logging {
+
+  def components: Vector[IView[Int]]
+
+  protected def renderOnKeyDown: Boolean = EuclidJsApp.currentScene.contains(this)
+
+  override def render(): Unit = {
+    log.debug("render")
+    display.clear()
+    components.foreach(_.render(display))
+  }
+
+  override def onKeyDown(event: KeyboardEvent[Int]): Unit = {
+    components.foreach(_.onKeyDown(event))
+    if (renderOnKeyDown) {
+      render()
+    }
+  }
+
+  protected def textView(shape: Rectangle, model: TextViewModel) = new TextView[Int](shape, model)
+  protected def textView(model: TextViewModel): TextView[Int] =
+    textView(Rectangle(0, 0, display.width, display.height), model)
+  protected def textView(text: String): TextView[Int] = textView(new StaticTextViewModel(text))
+  protected def menu(model: MenuViewModel): MenuView[Int] = new MenuView[Int](model) {
+    override val keyMap = Map(
+      ROT.VK_UP -> viewModel.up _,
+      ROT.VK_DOWN -> viewModel.down _,
+      ROT.VK_RETURN -> viewModel.execute _
+    )
+  }
+}

--- a/js/src/main/scala/ru/org/codingteam/rotjs/DisplayOptions.scala
+++ b/js/src/main/scala/ru/org/codingteam/rotjs/DisplayOptions.scala
@@ -1,0 +1,22 @@
+package ru.org.codingteam.rotjs
+
+import scala.scalajs.js
+
+trait DisplayOptions extends js.Object {
+
+  var bg: String = ???
+  var border: Int = ???
+  var fg: String = ???
+  var fontFamily: String = ???
+  var fontSize: Int = ???
+  var fontStyle: String = ???
+  var height: Int = ???
+  var layout: String = ???
+  var tileHeight: Int = ???
+  var tileMap: Any = ???
+  var tileSet: Any = ???
+  var tileWidth: Int = ???
+  var spacing: Int = ???
+  var width: Int = ???
+
+}

--- a/js/src/main/scala/ru/org/codingteam/rotjs/ROT.scala
+++ b/js/src/main/scala/ru/org/codingteam/rotjs/ROT.scala
@@ -1,0 +1,48 @@
+package ru.org.codingteam.rotjs
+
+import org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.annotation.JSImport.Namespace
+
+@JSImport("rot-js", Namespace)
+object ROT extends js.Object {
+
+  def VK_A: Int = ???
+  def VK_CLOSE_BRACKET: Int = ???
+  def VK_DOWN: Int = ???
+  def VK_ENTER: Int = ???
+  def VK_ESCAPE: Int = ???
+  def VK_I: Int = ???
+  def VK_LEFT: Int = ???
+  def VK_NUMPAD0: Int = ???
+  def VK_NUMPAD1: Int = ???
+  def VK_NUMPAD2: Int = ???
+  def VK_NUMPAD3: Int = ???
+  def VK_NUMPAD4: Int = ???
+  def VK_NUMPAD5: Int = ???
+  def VK_NUMPAD6: Int = ???
+  def VK_NUMPAD7: Int = ???
+  def VK_NUMPAD8: Int = ???
+  def VK_NUMPAD9: Int = ???
+  def VK_OPEN_BRACKET: Int = ???
+  def VK_RETURN: Int = ???
+  def VK_RIGHT: Int = ???
+  def VK_UP: Int = ???
+
+  class Display(options: DisplayOptions = ???) extends js.Object {
+
+    def clear(): Unit = ???
+    def getContainer(): dom.Node = ???
+    def getOptions(): DisplayOptions = ???
+    def draw(x: Int, y: Int, ch: String, fg: String = null, bg: String = null): Unit = ???
+    def draw(x: Int, y: Int, ch: Array[String], fg: String, bg: String): Unit = ???
+    def drawText(x: Int, y: Int, text: String, maxWidth: Int = 0): Int = ???
+  }
+
+  object Text extends js.Object {
+
+    def measure(str: String, maxWidth: Int = 0): TextBlockSize = ???
+  }
+}

--- a/js/src/main/scala/ru/org/codingteam/rotjs/TextBlockSize.scala
+++ b/js/src/main/scala/ru/org/codingteam/rotjs/TextBlockSize.scala
@@ -1,0 +1,10 @@
+package ru.org.codingteam.rotjs
+
+import scala.scalajs.js
+
+class TextBlockSize extends js.Object {
+
+  def width: Int = ???
+  def height: Int = ???
+
+}

--- a/jvm/src/main/scala/ru/org/codingteam/euclid/EuclidJvmApp.scala
+++ b/jvm/src/main/scala/ru/org/codingteam/euclid/EuclidJvmApp.scala
@@ -2,6 +2,6 @@ package ru.org.codingteam.euclid
 
 object EuclidJvmApp {
   def main(args: Array[String]): Unit = {
-    Euclid.hello(args)
+    println("Hello JVM world")
   }
 }

--- a/jvm/src/main/scala/ru/org/codingteam/euclid/jvm/EuclidJvmApp.scala
+++ b/jvm/src/main/scala/ru/org/codingteam/euclid/jvm/EuclidJvmApp.scala
@@ -1,4 +1,4 @@
-package ru.org.codingteam.euclid
+package ru.org.codingteam.euclid.jvm
 
 object EuclidJvmApp {
   def main(args: Array[String]): Unit = {

--- a/jvm/src/test/scala/ru/org/codingteam/euclid/js/TestJvm.scala
+++ b/jvm/src/test/scala/ru/org/codingteam/euclid/js/TestJvm.scala
@@ -1,4 +1,4 @@
-package ru.org.codingteam.euclid
+package ru.org.codingteam.euclid.js
 
 import collection.mutable.Stack
 import org.scalatest._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")

--- a/shared/src/main/scala/ru/org/codingteam/euclid/Euclid.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/Euclid.scala
@@ -1,7 +1,0 @@
-package ru.org.codingteam.euclid
-
-object Euclid {
-  def hello(args: Array[String]): Unit = {
-    println("Hello world!")
-  }
-}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/IView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/IView.scala
@@ -1,0 +1,10 @@
+package ru.org.codingteam.euclid
+
+import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
+
+trait IView[TKeyCode] {
+
+  def render(display: Display): Unit
+  def onKeyDown(event: KeyboardEvent[TKeyCode]): Unit
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/KeyMapView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/KeyMapView.scala
@@ -2,7 +2,7 @@ package ru.org.codingteam.euclid
 
 import ru.org.codingteam.euclid.io.KeyboardEvent
 
-trait KeyMapView[KeyCode, Event] extends IView[KeyCode] {
+trait KeyMapView[KeyCode, Event] extends View[KeyCode] {
 
   def keyMap: Map[Event, () => Unit]
   def mapEvent(event: KeyboardEvent[KeyCode]): Event

--- a/shared/src/main/scala/ru/org/codingteam/euclid/KeyMapView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/KeyMapView.scala
@@ -1,0 +1,16 @@
+package ru.org.codingteam.euclid
+
+import ru.org.codingteam.euclid.io.KeyboardEvent
+
+trait KeyMapView[KeyCode, Event] extends IView[KeyCode] {
+
+  def keyMap: Map[Event, () => Unit]
+  def mapEvent(event: KeyboardEvent[KeyCode]): Event
+
+  override def onKeyDown(event: KeyboardEvent[KeyCode]): Unit = {
+    val key = mapEvent(event)
+    val action = keyMap.get(key)
+    action map(_())
+  }
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/SimpleKeyMapView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/SimpleKeyMapView.scala
@@ -1,0 +1,9 @@
+package ru.org.codingteam.euclid
+
+import ru.org.codingteam.euclid.io.KeyboardEvent
+
+trait SimpleKeyMapView[KeyCode] extends KeyMapView[KeyCode, KeyCode] {
+
+  def mapEvent(event: KeyboardEvent[KeyCode]) = event.keyCode
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/View.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/View.scala
@@ -2,9 +2,7 @@ package ru.org.codingteam.euclid
 
 import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
 
-trait IView[TKeyCode] {
-
+trait View[TKeyCode] {
   def render(display: Display): Unit
   def onKeyDown(event: KeyboardEvent[TKeyCode]): Unit
-
 }

--- a/shared/src/main/scala/ru/org/codingteam/euclid/io/Display.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/io/Display.scala
@@ -1,0 +1,27 @@
+package ru.org.codingteam.euclid.io
+
+trait Display {
+
+  val textMeasurement: TextMeasurementService
+
+  def draw(x: Int, y: Int, ch: String, fg: String = null, bg: String = null): Unit
+
+  def draw(x: Int, y: Int, ch: Array[String], fg: String, bg: String): Unit
+
+  def drawText(x: Int, y: Int, text: String, maxWidth: Int = 0): Int
+
+  def width: Int
+
+  def height: Int
+
+  def drawTextCentered(x: Int, y: Int, width: Int, height: Int, text: String, topPadding: Option[Int]): Unit = {
+    val measurement = textMeasurement.measure(text, width)
+
+    val realX = x + (width - measurement.width) / 2
+    val realY = y + topPadding.getOrElse((height - measurement.height) / 2)
+
+    drawText(realX, realY, text)
+  }
+
+  def drawTextCentered(text: String, y: Option[Int] = None): Unit = drawTextCentered(0, 0, width, height, text, y)
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/io/Display.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/io/Display.scala
@@ -24,4 +24,9 @@ trait Display {
   }
 
   def drawTextCentered(text: String, y: Option[Int] = None): Unit = drawTextCentered(0, 0, width, height, text, y)
+
+  /**
+    * Clears the display.
+    */
+  def clear()
 }

--- a/shared/src/main/scala/ru/org/codingteam/euclid/io/KeyboardEvent.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/io/KeyboardEvent.scala
@@ -1,0 +1,3 @@
+package ru.org.codingteam.euclid.io
+
+class KeyboardEvent[KeyCode](val keyCode: KeyCode)

--- a/shared/src/main/scala/ru/org/codingteam/euclid/io/TextBlockSize.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/io/TextBlockSize.scala
@@ -1,0 +1,3 @@
+package ru.org.codingteam.euclid.io
+
+class TextBlockSize(val width: Int, val height: Int)

--- a/shared/src/main/scala/ru/org/codingteam/euclid/io/TextMeasurementService.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/io/TextMeasurementService.scala
@@ -1,0 +1,5 @@
+package ru.org.codingteam.euclid.io
+
+trait TextMeasurementService {
+  def measure(text: String, width: Int): TextBlockSize
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/shape/Rectangle.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/shape/Rectangle.scala
@@ -1,0 +1,3 @@
+package ru.org.codingteam.euclid.shape
+
+case class Rectangle(x: Int, y: Int, width: Int, height: Int)

--- a/shared/src/main/scala/ru/org/codingteam/euclid/util/Logging.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/util/Logging.scala
@@ -1,0 +1,96 @@
+package ru.org.codingteam.euclid.util
+
+/**
+ * Trait which initializes instance of logger with object's classname.
+ */
+trait Logging {
+  
+  lazy val log = new Logging.Logger(getClass.getName)
+
+}
+
+object Logging {
+
+  /**
+   * Simple logging implementation.
+   * It should be replaced by (or should delegate to) logger from some framework like scala-logging.
+   */
+  class Logger(name: String) {
+
+    object Level extends Enumeration {
+      val Debug, Info, Warning, Error = Value
+    }
+
+    // TODO: load log level and additional configuration from config.
+    val level = Level.Debug
+
+    val isDebugEnabled = level <= Level.Debug
+    val isInfoEnabled = level <= Level.Info
+    val isWarningEnabled = level <= Level.Warning
+    val isErrorEnabled = level <= Level.Error
+
+    val out = System.out
+
+    /** Name in converted form (e.g. java.util.List => j.u.List).  */
+    lazy val convertedName = {
+      val components = name split "\\."
+      components.take(components.size - 1).map(_ take 1) :+ components.last mkString "."
+    }
+
+    // TODO: the above methods should be a macros (like in scala-logging).
+
+    def debug(msg: => String): Unit = {
+      if (isDebugEnabled) {
+        out.println(s"DEBUG $convertedName: $msg")
+      }
+    }
+
+    def debug(msg: => String, cause: Throwable): Unit = {
+      if (isDebugEnabled) {
+        out.println(s"DEBUG $convertedName: $msg")
+        cause.printStackTrace(out)
+      }
+    }
+
+    def info(msg: => String): Unit = {
+      if (isInfoEnabled) {
+        out.println(s"INFO $convertedName: $msg")
+      }
+    }
+
+    def info(msg: => String, cause: Throwable): Unit = {
+      if (isInfoEnabled) {
+        out.println(s"INFO $convertedName: $msg")
+        cause.printStackTrace(out)
+      }
+    }
+
+    def warn(msg: => String): Unit = {
+      if (isWarningEnabled) {
+        out.println(s"WARN $convertedName: $msg")
+      }
+    }
+
+    def warn(msg: => String, cause: Throwable): Unit = {
+      if (isWarningEnabled) {
+        out.println(s"WARN $convertedName: $msg")
+        cause.printStackTrace(out)
+      }
+    }
+
+    def error(msg: => String): Unit = {
+      if (isErrorEnabled) {
+        out.println(s"ERROR $convertedName: $msg")
+      }
+    }
+
+    def error(msg: => String, cause: Throwable): Unit = {
+      if (isErrorEnabled) {
+        out.println(s"ERROR $convertedName: $msg")
+        cause.printStackTrace(out)
+      }
+    }
+
+  }
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/util/VectorMap.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/util/VectorMap.scala
@@ -1,0 +1,19 @@
+package ru.org.codingteam.euclid.util
+
+import scala.collection.immutable.ListMap
+
+class VectorMap[Key, Value] private (items: (Key, Value)*) {
+
+  val map = ListMap(items: _*)
+  val vector = Vector(items: _*)
+
+  def apply(index: Int) = vector(index)
+  def apply(key: Key) = map(key)
+  def isEmpty = map.isEmpty
+  def size = map.size
+}
+
+object VectorMap {
+
+  def apply[Key, Value](items: (Key, Value)*) = new VectorMap(items: _*)
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/ItemsViewModel.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/ItemsViewModel.scala
@@ -1,0 +1,46 @@
+package ru.org.codingteam.euclid.viewmodels
+
+import ru.org.codingteam.euclid.util.VectorMap
+
+class ItemsViewModel[T](initialItems: VectorMap[T, String]) {
+
+  private var _items: VectorMap[T, String] = initialItems
+  private var _selectedIndex: Option[Int] = initialIndex()
+
+  def items = _items
+  def items_=(newItems: VectorMap[T, String]): Unit = {
+    _items = newItems
+    _selectedIndex = initialIndex()
+  }
+
+  def selectedIndex = _selectedIndex
+  def selectedIndex_=(newIndex: Option[Int]): Unit = {
+    newIndex match {
+      case None =>
+        _selectedIndex = newIndex
+      case Some(index) if _items.isEmpty => // Nothing
+      case Some(index) if index < 0 =>
+        _selectedIndex = Some(_items.size - 1)
+      case Some(index) if index >= _items.size =>
+        _selectedIndex = Some(0)
+      case Some(index) =>
+        _selectedIndex = newIndex
+    }
+
+    onSelectedItemChanged(selectedItem)
+  }
+
+  def selectedItem = _selectedIndex map { index => _items(index)._1 }
+
+  def up(): Unit = {
+    _selectedIndex foreach { value => selectedIndex = Some(value - 1) }
+  }
+
+  def down(): Unit = {
+    _selectedIndex foreach { value => selectedIndex = Some(value + 1) }
+  }
+
+  protected def onSelectedItemChanged(item: Option[T]) = ()
+
+  private def initialIndex(): Option[Int] = _items.vector.headOption.map(_ => 0)
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/MenuViewModel.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/MenuViewModel.scala
@@ -3,7 +3,7 @@ package ru.org.codingteam.euclid.viewmodels
 import ru.org.codingteam.euclid.util.Logging
 
 abstract class MenuViewModel extends Logging {
-
+  val header: String
   val items: Seq[(String, () => Unit)]
   var selectedItem: Int = 0
 
@@ -24,5 +24,4 @@ abstract class MenuViewModel extends Logging {
 
     log.debug(s"selectedItem became $selectedItem")
   }
-
 }

--- a/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/MenuViewModel.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/MenuViewModel.scala
@@ -1,0 +1,28 @@
+package ru.org.codingteam.euclid.viewmodels
+
+import ru.org.codingteam.euclid.util.Logging
+
+abstract class MenuViewModel extends Logging {
+
+  val items: Seq[(String, () => Unit)]
+  var selectedItem: Int = 0
+
+  def up(): Unit = change(-1)
+  def down(): Unit = change(1)
+  def execute(): Unit = items(selectedItem)._2()
+
+  private def change(delta: Int): Unit = {
+    log.debug(s"delta = $delta")
+    log.debug(s"selectedItem = $selectedItem")
+    log.debug(s"items = $items")
+
+    selectedItem = selectedItem + delta match {
+      case x if x < 0 => items.length - 1
+      case x if x >= items.length => 0
+      case other => other
+    }
+
+    log.debug(s"selectedItem became $selectedItem")
+  }
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/StaticTextViewModel.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/StaticTextViewModel.scala
@@ -1,0 +1,5 @@
+package ru.org.codingteam.euclid.viewmodels
+
+class StaticTextViewModel(override val text: String) extends TextViewModel {
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/TextViewModel.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/viewmodels/TextViewModel.scala
@@ -1,0 +1,7 @@
+package ru.org.codingteam.euclid.viewmodels
+
+abstract class TextViewModel {
+
+  def text: String
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/ListView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/ListView.scala
@@ -42,16 +42,4 @@ class ListView[KeyCode, T](shape: Rectangle,
 object ListView {
 
   type KeyMap[KeyCode] = Map[KeyCode, () => Unit]
-
-  def bracketKeyMap[KeyCode, T](model: ItemsViewModel[T]): KeyMap[KeyCode] = Map(
-    // TODO[F]: Define these at the platform level.
-    // ROT.VK_OPEN_BRACKET -> model.up _,
-    // ROT.VK_CLOSE_BRACKET -> model.down _
-  )
-
-  def arrowKeyMap[KeyCode, T](model: ItemsViewModel[T]): KeyMap[KeyCode] = Map(
-    // TODO[F]: Define these at the platform level.
-    // ROT.VK_UP -> model.up _,
-    // ROT.VK_DOWN -> model.down _
-  )
 }

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/ListView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/ListView.scala
@@ -1,0 +1,57 @@
+package ru.org.codingteam.euclid.views
+
+import ru.org.codingteam.euclid.SimpleKeyMapView
+import ru.org.codingteam.euclid.io.Display
+import ru.org.codingteam.euclid.shape.Rectangle
+import ru.org.codingteam.euclid.viewmodels.ItemsViewModel
+
+/**
+ * A list of typed items.
+ */
+class ListView[KeyCode, T](shape: Rectangle,
+                  model: ItemsViewModel[T],
+                  override val keyMap: ListView.KeyMap[KeyCode]) extends SimpleKeyMapView[KeyCode] {
+
+  /**
+   * A pair of model item and its name.
+   */
+  protected type Item = (T, String)
+
+  override def render(display: Display): Unit = {
+    val margin = 1
+    model.items.vector.zipWithIndex foreach { case (item, index) =>
+      val y = shape.y + index
+      if (index > shape.height) {
+        return
+      }
+
+      renderItem(display, item, shape.x + margin, y, shape.width - 2 * margin)
+    }
+  }
+
+  protected def renderItem(display: Display, item: Item, x: Int, y: Int, width: Int): Unit = {
+    val (value, name) = item
+    if (model.selectedItem.contains(value)) {
+      display.draw(shape.x, y, ">")
+    }
+
+    display.drawText(x, y, name, width)
+  }
+}
+
+object ListView {
+
+  type KeyMap[KeyCode] = Map[KeyCode, () => Unit]
+
+  def bracketKeyMap[KeyCode, T](model: ItemsViewModel[T]): KeyMap[KeyCode] = Map(
+    // TODO[F]: Define these at the platform level.
+    // ROT.VK_OPEN_BRACKET -> model.up _,
+    // ROT.VK_CLOSE_BRACKET -> model.down _
+  )
+
+  def arrowKeyMap[KeyCode, T](model: ItemsViewModel[T]): KeyMap[KeyCode] = Map(
+    // TODO[F]: Define these at the platform level.
+    // ROT.VK_UP -> model.up _,
+    // ROT.VK_DOWN -> model.down _
+  )
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
@@ -8,8 +8,9 @@ import ru.org.codingteam.euclid.viewmodels.MenuViewModel
 abstract class MenuView[KeyCode](val viewModel: MenuViewModel) extends SimpleKeyMapView[KeyCode] with Logging {
 
   override def render(display: Display): Unit = {
-    display.drawTextCentered("Keter", Some(1))
-    display.drawTextCentered("=====", Some(2))
+    val header = viewModel.header
+    display.drawTextCentered(header, Some(1))
+    display.drawTextCentered("=" * header.length, Some(2))
 
     val base = 4
     viewModel.items.zipWithIndex.foreach { case ((name, action), index) =>

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
@@ -1,0 +1,33 @@
+package ru.org.codingteam.euclid.views
+
+import ru.org.codingteam.euclid.SimpleKeyMapView
+import ru.org.codingteam.euclid.io.Display
+import ru.org.codingteam.euclid.util.Logging
+import ru.org.codingteam.euclid.viewmodels.MenuViewModel
+
+class MenuView[KeyCode](viewModel: MenuViewModel) extends SimpleKeyMapView[KeyCode] with Logging {
+
+  val keyMap = Map(
+    // TODO[F]: Define these at the platform level.
+    //ROT.VK_UP -> viewModel.up _,
+    //ROT.VK_DOWN -> viewModel.down _,
+    //ROT.VK_RETURN -> viewModel.execute _
+  )
+
+  override def render(display: Display): Unit = {
+    display.drawTextCentered("Keter", Some(1))
+    display.drawTextCentered("=====", Some(2))
+
+    val base = 4
+    viewModel.items.zipWithIndex.foreach { case ((name, action), index) =>
+      val (indent, text) = if (index == viewModel.selectedItem) {
+        (2, s"> %b{#fff}%c{#000}$name%c{}%b{}")
+      } else {
+        (4, name)
+      }
+
+      display.drawText(indent, base + index, text)
+    }
+  }
+
+}

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/MenuView.scala
@@ -5,14 +5,7 @@ import ru.org.codingteam.euclid.io.Display
 import ru.org.codingteam.euclid.util.Logging
 import ru.org.codingteam.euclid.viewmodels.MenuViewModel
 
-class MenuView[KeyCode](viewModel: MenuViewModel) extends SimpleKeyMapView[KeyCode] with Logging {
-
-  val keyMap = Map(
-    // TODO[F]: Define these at the platform level.
-    //ROT.VK_UP -> viewModel.up _,
-    //ROT.VK_DOWN -> viewModel.down _,
-    //ROT.VK_RETURN -> viewModel.execute _
-  )
+abstract class MenuView[KeyCode](val viewModel: MenuViewModel) extends SimpleKeyMapView[KeyCode] with Logging {
 
   override def render(display: Display): Unit = {
     display.drawTextCentered("Keter", Some(1))
@@ -29,5 +22,4 @@ class MenuView[KeyCode](viewModel: MenuViewModel) extends SimpleKeyMapView[KeyCo
       display.drawText(indent, base + index, text)
     }
   }
-
 }

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/TextView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/TextView.scala
@@ -1,11 +1,11 @@
 package ru.org.codingteam.euclid.views
 
-import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.View
 import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
 import ru.org.codingteam.euclid.shape.Rectangle
 import ru.org.codingteam.euclid.viewmodels.TextViewModel
 
-class TextView[TKeyCode](shape: Rectangle, model: TextViewModel) extends IView[TKeyCode] {
+class TextView[TKeyCode](shape: Rectangle, model: TextViewModel) extends View[TKeyCode] {
 
   override def render(display: Display): Unit = {
     display.drawTextCentered(shape.x, shape.y, shape.width, shape.height, model.text, None)

--- a/shared/src/main/scala/ru/org/codingteam/euclid/views/TextView.scala
+++ b/shared/src/main/scala/ru/org/codingteam/euclid/views/TextView.scala
@@ -1,0 +1,15 @@
+package ru.org.codingteam.euclid.views
+
+import ru.org.codingteam.euclid.IView
+import ru.org.codingteam.euclid.io.{Display, KeyboardEvent}
+import ru.org.codingteam.euclid.shape.Rectangle
+import ru.org.codingteam.euclid.viewmodels.TextViewModel
+
+class TextView[TKeyCode](shape: Rectangle, model: TextViewModel) extends IView[TKeyCode] {
+
+  override def render(display: Display): Unit = {
+    display.drawTextCentered(shape.x, shape.y, shape.width, shape.height, model.text, None)
+  }
+
+  override def onKeyDown(event: KeyboardEvent[TKeyCode]): Unit = ()
+}

--- a/shared/src/test/scala/ru/org/codingteam/euclid/js/TestShared.scala
+++ b/shared/src/test/scala/ru/org/codingteam/euclid/js/TestShared.scala
@@ -1,4 +1,4 @@
-package ru.org.codingteam.euclid
+package ru.org.codingteam.euclid.js
 
 import collection.mutable.Stack
 import org.scalatest._


### PR DESCRIPTION
This is a first step necessary for #3.

I've essentially extracted the `ui` package from Keter and added small platform abstractions (mainly the `KeyCode`) here and there. I've also added a small test application that works (tested manually).

**The goal of this PR is not to change the code architecture, we will do that later.** For now, we're just importing the old code and making sure it works.

**TODO:**

- [x] ~~abstract the keybindings~~ _removed them from the shared code for now_